### PR TITLE
Removed message dialogue created when changing nickname.

### DIFF
--- a/bukkit/rpk-characters-bukkit/src/main/kotlin/com/rpkit/characters/bukkit/command/character/set/CharacterSetNameCommand.kt
+++ b/bukkit/rpk-characters-bukkit/src/main/kotlin/com/rpkit/characters/bukkit/command/character/set/CharacterSetNameCommand.kt
@@ -103,7 +103,6 @@ class CharacterSetNameCommand(private val plugin: RPKCharactersBukkit) : RPKComm
                 reloadPlayer(bukkitPlayer, character, plugin.server.onlinePlayers.filter { it.uniqueId != sender.minecraftUUID })
             }
             sender.sendMessage(plugin.messages["character-set-name-valid"])
-            updatedCharacter?.showCharacterCard(sender)
             return@thenApply CommandSuccess
         }
     }


### PR DESCRIPTION
Removed line 106 as requested. Will look for alternatives to indicate character sheet changes when changing nicknames, but this fix should suffice for now.