### PR TITLE
Added script to gather jars.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ build/
 
 repo.properties
 github.properties
+
+gathered_jars/

--- a/gather_jars.sh
+++ b/gather_jars.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+current_dir=$(pwd)
+target_dir=$current_dir/gathered_jars
+
+mkdir -p $target_dir
+
+# gather jars with -all suffix in all subdirectories
+for i in $(find . -name "*-all.jar"); do
+    cp $i $target_dir
+done


### PR DESCRIPTION
## Problem
Going to each module's build/libs directory can be cumbersome.

## Solution
A script has been added to gather files ending in `-all.JAR`.

## Testing
This has been verified to gather the correct JARs as expected.