### PR TITLE
Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:17-jdk
+
+WORKDIR /workspaces/RPKit

--- a/.devcontainer/start_dev_container.sh
+++ b/.devcontainer/start_dev_container.sh
@@ -1,0 +1,2 @@
+docker build . -t rpk-dev-container
+docker run -it -v $(pwd)/../:/workspaces/RPKit rpk-dev-container /bin/bash


### PR DESCRIPTION
## Problem
As of right now, the user needs to set up their environment in order to compile the plugin suite.

## Solution
A dev container has been added to the project.

## Testing
This has been tested locally on a Linux machine by running `start_dev_container.sh` script with Docker running.