### PR TITLE
Updated dev container to use eclipse-temurin:17-jdk-jammy as base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,6 @@
-FROM openjdk:17-jdk
+FROM eclipse-temurin:17-jdk-jammy
 
+USER root
+
+# set working directory
 WORKDIR /workspaces/RPKit

--- a/README.md
+++ b/README.md
@@ -10,5 +10,14 @@ The main branch for this fork of the project is backport/v2.3.3-1.18, which was 
 ## Set Chat Name Color
 The purpose of this fork is to work on the [Customizable Chat Name Colors](https://github.com/RP-Kit/RPKit/issues/658) work item.
 
+## How To Build
+1. Install Docker if you don't have it already installed.
+1. Reopen project in dev container by running the following:
+```
+cd .devcontainer
+./start_dev_container.sh
+```
+1. Run `./gradlew clean build` to build the project.
+
 ## Testing
 Testing can be done using the [rpk-mc-server](https://github.com/dmccoystephenson/rpk-mc-server) project.


### PR DESCRIPTION
## Problem
There are not many tools in the current dev container, so it's difficult to use.

## Solution
The base image for the dev container has been switched to eclipse-temurin

## Testing
The project can be compiled in the provided dev container.