### PR TITLE
Allow Operators To Change Players' Chat Name Colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ cd .devcontainer
 
 ## Testing
 Testing can be done using the [rpk-mc-server](https://github.com/dmccoystephenson/rpk-mc-server) project.
+
+## Troubleshooting
+### Cannot lock checksums cache (/workspaces/RPKit/.gradle/checksums) as it has already been locked by this process.
+This error can occur when trying to build the project. To resolve this issue, run the following:
+```
+./gradlew --stop
+```
+This will stop the gradle daemon and allow you to build the project.

--- a/bukkit/rpk-chat-bukkit/src/main/resources/plugin.yml
+++ b/bukkit/rpk-chat-bukkit/src/main/resources/plugin.yml
@@ -106,3 +106,6 @@ permissions:
   rpkit.chat.command.setchatnamecolor:
     description: Allows setting the color of your name in chat
     default: true
+  rpkit.chat.command.setchatnamecolor.others:
+    description: Allows setting the color of your name in chat
+    default: op


### PR DESCRIPTION
## Problem
Operators are not able to change the chat name colors of other players at this time.

## Solution
The `setchatnamecolor` command has been modified to allow those with permission to set the chat name colors of other players by adding the player name after the hex code as a second argument.

## Testing
This was tested on a local instance of rpk-mc-server and the following was verified:
- The plugin is recognized
- With permission, players can set their chat name color using the new syntax
- Without permission, attempting to use the new syntax results in a "you don't have permission" message.

## Relevant Issue
Closes #10 