### PR TITLE
Exclude Channels From Chat Name Color Functionality

### DIFF
--- a/bukkit/rpk-chat-bukkit/src/main/kotlin/com/rpkit/chat/bukkit/chatchannel/RPKChatChannelImpl.kt
+++ b/bukkit/rpk-chat-bukkit/src/main/kotlin/com/rpkit/chat/bukkit/chatchannel/RPKChatChannelImpl.kt
@@ -171,7 +171,9 @@ class RPKChatChannelImpl(
                         format.flatMap { part -> part.toChatComponents(preFormatContext).join().toList() }.toTypedArray(),
                         preFormatContext.isCancelled
                     )
-                    if (senderMinecraftProfile != null) {
+                    
+                    val excludedChatChannels = plugin.config.getList("rpk_channels_excluded_for_chat_name_color_functionality")
+                    if (excludedChatChannels != null && !excludedChatChannels.contains(name.value) && senderMinecraftProfile != null) {
                         val minecraftProfileId = senderMinecraftProfile.id
                         if (minecraftProfileId != null) {
                             val recordExists = plugin.database.getTable(RPKChatNameColorTable::class.java).get(minecraftProfileId).join() != null

--- a/bukkit/rpk-chat-bukkit/src/main/resources/config.yml
+++ b/bukkit/rpk-chat-bukkit/src/main/resources/config.yml
@@ -388,4 +388,7 @@ caching:
     minecraft_profile_id:
       enabled: true
       size: 20
-
+rpk_channels_excluded_for_chat_name_color_functionality:
+- general
+- support
+- staff


### PR DESCRIPTION
## Problem
Some users may not want chat name colors to show up in certain channels.

## Solution
It is now possible to exclude channels from the chat name color functionality via the config.yml

## Testing
This was tested on a local instance of `rpk-mc-server`

## Relevant Issue
Closes #11 