### PR TITLE
Fixed delayed chat name color usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ allprojects {
     apply plugin: "maven-publish"
     apply plugin: "org.jetbrains.dokka"
     group = "com.rpkit"
-    version = "2.3.3-mc1.18-1"
+    version = "2.3.3.2-mc1.18-1"
 }
 
 subprojects {

--- a/bukkit/rpk-chat-bukkit/src/main/kotlin/com/rpkit/chat/bukkit/chatchannel/RPKChatChannelImpl.kt
+++ b/bukkit/rpk-chat-bukkit/src/main/kotlin/com/rpkit/chat/bukkit/chatchannel/RPKChatChannelImpl.kt
@@ -171,26 +171,6 @@ class RPKChatChannelImpl(
                         format.flatMap { part -> part.toChatComponents(preFormatContext).join().toList() }.toTypedArray(),
                         preFormatContext.isCancelled
                     )
-                    
-                    val excludedChatChannels = plugin.config.getList("rpk_channels_excluded_for_chat_name_color_functionality")
-                    if (excludedChatChannels != null && !excludedChatChannels.contains(name.value) && senderMinecraftProfile != null) {
-                        val minecraftProfileId = senderMinecraftProfile.id
-                        if (minecraftProfileId != null) {
-                            val recordExists = plugin.database.getTable(RPKChatNameColorTable::class.java).get(minecraftProfileId).join() != null
-                            if (recordExists) {
-                                for (part in format) {
-                                    if (part is SenderCharacterNamePart) {
-                                        val chatNameColorRecord = plugin.database.getTable(RPKChatNameColorTable::class.java).get(minecraftProfileId).join()
-                                        if (chatNameColorRecord != null) {
-                                            part.color = chatNameColorRecord.chatNameColor
-                                            break
-                                        }
-                                        break
-                                    }
-                                }
-                            }
-                        }
-                    }
 
                     directedPostFormatPipeline.forEach { component ->
                         postFormatContext = component.process(postFormatContext).join()

--- a/bukkit/rpk-chat-bukkit/src/main/kotlin/com/rpkit/chat/bukkit/chatchannel/format/part/ReceiverCharacterNamePart.kt
+++ b/bukkit/rpk-chat-bukkit/src/main/kotlin/com/rpkit/chat/bukkit/chatchannel/format/part/ReceiverCharacterNamePart.kt
@@ -21,7 +21,10 @@ import com.rpkit.chat.bukkit.RPKChatBukkit
 import com.rpkit.chat.bukkit.chatchannel.format.click.ClickAction
 import com.rpkit.chat.bukkit.chatchannel.format.hover.HoverAction
 import com.rpkit.chat.bukkit.context.DirectedPreFormatMessageContext
+import com.rpkit.chat.bukkit.database.table.RPKChatNameColorTable
 import com.rpkit.core.service.Services
+import net.md_5.bungee.api.ChatColor
+import net.md_5.bungee.api.chat.TextComponent
 import org.bukkit.Bukkit
 import org.bukkit.configuration.serialization.ConfigurationSerializable
 import org.bukkit.configuration.serialization.SerializableAs
@@ -93,5 +96,52 @@ class ReceiverCharacterNamePart(
             serialized["hover"] as? HoverAction,
             serialized["click"] as? ClickAction
         )
+    }
+
+    override fun toChatComponents(context: DirectedPreFormatMessageContext) = supplyAsync {
+        TextComponent.fromLegacyText(getText(context).join()).also {
+            for (component in it) {
+
+                if (font != null) component.font = font
+                component.color = getChatNameColor(context)
+                if (isBold != null) component.isBold = isBold
+                if (isItalic != null) component.isItalic = isItalic
+                if (isUnderlined != null) component.isUnderlined = isUnderlined
+                if (isStrikethrough != null) component.isStrikethrough = isStrikethrough
+                if (isObfuscated != null) component.isObfuscated = isObfuscated
+                if (insertion != null) component.insertion = insertion
+                if (hover != null) component.hoverEvent = hover.toHoverEvent(context).join()
+                if (click != null) component.clickEvent = click.toClickEvent(context).join()
+            }
+        }
+    }.exceptionally { exception ->
+        plugin.logger.log(Level.SEVERE, "Failed to convert text part to chat components", exception)
+        throw exception
+    }
+
+    // method to get chat name color
+    private fun getChatNameColor(context: DirectedPreFormatMessageContext): ChatColor {
+        // check if chat channel is excluded from chat name color functionality
+        val excludedChatChannels = plugin.config.getList("rpk_channels_excluded_for_chat_name_color_functionality")
+        if (excludedChatChannels != null && !excludedChatChannels.contains(context.chatChannel.name.value) && context.senderMinecraftProfile != null) {
+            // try to use chat name color from database
+            val minecraftProfile = context.senderMinecraftProfile
+            if (minecraftProfile != null) {
+                val minecraftProfileId = minecraftProfile.id
+                if (minecraftProfileId != null) {
+                    val chatNameColorRecord = plugin.database.getTable(RPKChatNameColorTable::class.java)[minecraftProfileId].join()
+                    if (chatNameColorRecord != null) {
+                        return ChatColor.of(chatNameColorRecord.chatNameColor)
+                    }
+                }
+            }
+        }
+        return if (color == null) {
+            // default color
+            ChatColor.WHITE
+        } else {
+            // color from configuration
+            ChatColor.of(color)
+        }
     }
 }

--- a/bukkit/rpk-chat-bukkit/src/main/kotlin/com/rpkit/chat/bukkit/chatchannel/format/part/SenderCharacterNamePart.kt
+++ b/bukkit/rpk-chat-bukkit/src/main/kotlin/com/rpkit/chat/bukkit/chatchannel/format/part/SenderCharacterNamePart.kt
@@ -21,7 +21,10 @@ import com.rpkit.chat.bukkit.RPKChatBukkit
 import com.rpkit.chat.bukkit.chatchannel.format.click.ClickAction
 import com.rpkit.chat.bukkit.chatchannel.format.hover.HoverAction
 import com.rpkit.chat.bukkit.context.DirectedPreFormatMessageContext
+import com.rpkit.chat.bukkit.database.table.RPKChatNameColorTable
 import com.rpkit.core.service.Services
+import net.md_5.bungee.api.ChatColor
+import net.md_5.bungee.api.chat.TextComponent
 import org.bukkit.Bukkit
 import org.bukkit.configuration.serialization.ConfigurationSerializable
 import org.bukkit.configuration.serialization.SerializableAs
@@ -97,5 +100,52 @@ class SenderCharacterNamePart(
             serialized["hover"] as? HoverAction,
             serialized["click"] as? ClickAction
         )
+    }
+
+    override fun toChatComponents(context: DirectedPreFormatMessageContext) = supplyAsync {
+        TextComponent.fromLegacyText(getText(context).join()).also {
+            for (component in it) {
+
+                if (font != null) component.font = font
+                component.color = getChatNameColor(context)
+                if (isBold != null) component.isBold = isBold
+                if (isItalic != null) component.isItalic = isItalic
+                if (isUnderlined != null) component.isUnderlined = isUnderlined
+                if (isStrikethrough != null) component.isStrikethrough = isStrikethrough
+                if (isObfuscated != null) component.isObfuscated = isObfuscated
+                if (insertion != null) component.insertion = insertion
+                if (hover != null) component.hoverEvent = hover.toHoverEvent(context).join()
+                if (click != null) component.clickEvent = click.toClickEvent(context).join()
+            }
+        }
+    }.exceptionally { exception ->
+        plugin.logger.log(Level.SEVERE, "Failed to convert text part to chat components", exception)
+        throw exception
+    }
+
+    // method to get chat name color
+    private fun getChatNameColor(context: DirectedPreFormatMessageContext): ChatColor {
+        // check if chat channel is excluded from chat name color functionality
+        val excludedChatChannels = plugin.config.getList("rpk_channels_excluded_for_chat_name_color_functionality")
+        if (excludedChatChannels != null && !excludedChatChannels.contains(context.chatChannel.name.value) && context.senderMinecraftProfile != null) {
+            // try to use chat name color from database
+            val minecraftProfile = context.senderMinecraftProfile
+            if (minecraftProfile != null) {
+                val minecraftProfileId = minecraftProfile.id
+                if (minecraftProfileId != null) {
+                    val chatNameColorRecord = plugin.database.getTable(RPKChatNameColorTable::class.java)[minecraftProfileId].join()
+                    if (chatNameColorRecord != null) {
+                        return ChatColor.of(chatNameColorRecord.chatNameColor)
+                    }
+                }
+            }
+        }
+        return if (color == null) {
+            // default color
+            ChatColor.WHITE
+        } else {
+            // color from configuration
+            ChatColor.of(color)
+        }
     }
 }


### PR DESCRIPTION
## Problem
The use of a player's chat name color is currently delayed, meaning they need to chat twice before it takes effect.

## Solution
The chat name color code has been moved to the SenderCharacterNamePart & ReceiverCharacterNamePart classes in overridden `toChatComponents()` methods.

## Testing
Testing was done using rpk-mc-server & the chat name color usage is no longer delayed.

## Relevant Issues
Closes #13 
Closes #12 